### PR TITLE
removed broken file

### DIFF
--- a/vsa/vsa/gui.py
+++ b/vsa/vsa/gui.py
@@ -1,4 +1,0 @@
-
-class HRRVisualizer:
-
-    def 


### PR DESCRIPTION
with this file, pip install fails with:

```bash
byte-compiling build/bdist.linux-x86_64/egg/vsa/__init__.py to __init__.pyc
byte-compiling build/bdist.linux-x86_64/egg/vsa/test_path_intersection.py to test_path_intersection.pyc
byte-compiling build/bdist.linux-x86_64/egg/vsa/gui.py to gui.pyc
  File "build/bdist.linux-x86_64/egg/vsa/gui.py", line 4
    def
       ^
SyntaxError: invalid syntax


```